### PR TITLE
fix relative install path for updating packages

### DIFF
--- a/op-manager/oppm.lua
+++ b/op-manager/oppm.lua
@@ -396,8 +396,11 @@ local function installPackage(pack,path,update)
       if not string.find(j,"^//") then
         for k,v in pairs(tPacks[pack]) do
           if k==i then
-            path = string.gsub(fs.path(v),j.."/?$","/")
-            break
+            local proposed_path, matches = string.gsub(fs.path(v),j.."/?[^/]+$","/")
+            if matches == 1 then
+              path = proposed_path
+              break
+            end
           end
         end
         if path then


### PR DESCRIPTION
When oppm updates a package it searches for any existing file from the package that is still defined in the package install definition. The purpose of the code is then to remove the destination path suffix so as to leave the original relative path used by the user, in case it wasn't simply /usr (default).
gsub is used to remove the install path suffix, but the given string is the installed file path string and thus the regular expression needs to remove the file name from the path. My solution is to include any non / chars from the end of the string. This should leave the relative path root used in the original install.
Note however that this is not a completely safe expectation. If the pkg owner changes the install path completely on an existing repo file, this code would assume gsub would have removed a part of the path that no longer would exist. For this purpose I've added the matches count check. Note also that it is possible that not a single file in the pkg still matches the previous path endings. In this case, /usr would be used and it is possible that the pkg would install twice in two separate paths (in case the user specified a custom install path a previous time). It's rather low risk, but I thought I'd point it out.