### PR TITLE
Patch for repositories using 'main' instead of 'master'

### DIFF
--- a/oppm/lib/oppm.lua
+++ b/oppm/lib/oppm.lua
@@ -43,7 +43,10 @@ end
 local function getPackages(repo)
   local success, sPackages = pcall(getContent,"https://raw.githubusercontent.com/"..repo.."/master/programs.cfg")
   if not success or not sPackages then
-    return -1
+    success, sPackages = pcall(getContent,"https://raw.githubusercontent.com/"..repo.."/main/programs.cfg")
+    if not success or not sPackages then
+      return -1
+    end
   end
   return serial.unserialize(sPackages)
 end

--- a/oppm/oppm.lua
+++ b/oppm/oppm.lua
@@ -164,7 +164,10 @@ end)
 local getPackages = cached(function(repo)
   local success, sPackages = pcall(getContent,"https://raw.githubusercontent.com/"..repo.."/master/programs.cfg")
   if not success or not sPackages then
-    return -1
+    success, sPackages = pcall(getContent,"https://raw.githubusercontent.com/"..repo.."/main/programs.cfg")
+    if not success or not sPackages then
+	  return -1
+    end
   end
   return serial.unserialize(sPackages)
 end)


### PR DESCRIPTION
since new github repositories are defaulting to "main" instead of "master" as their default branch, oppm should be able to handle the new convention.

This patch does just that (albeit simply).