### PR TITLE
Attempt to create directories for external dependency files when installing.

### DIFF
--- a/oppm/oppm.lua
+++ b/oppm/oppm.lua
@@ -545,6 +545,9 @@ local function installPackage(pack,path,update,tPacks)
       end
       if string.lower(string.sub(i,1,4))=="http" then
         nPath = fs.concat(nPath, string.gsub(i,".+(/.-)$","%1"),nil)
+        if not fs.exists(fs.path(nPath)) then
+          fs.makeDirectory(fs.path(nPath))
+        end
         local success,response = pcall(downloadFile,i,nPath)
         if success and response then
           tPacks[pack][i] = nPath


### PR DESCRIPTION
A lot of my OC software lives on my personal Gitea server, and I can pull it in as a "dependency" in oppm, however, it doesn't create the directories for said files. This MR is basically just adding in a "if it doesn't exist, try to make a directory" when installing external dependency files.

I may have overlooked a cleaner way to do this, but it works.